### PR TITLE
fixed backward compatibility(47 and early)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -89,7 +89,8 @@ export default class QuickLangSwitchExtension extends Extension {
      * - stop returning any bool (was always true), and 
      * - added warn/error logs.
      */
-    _quickSwitchLayouts(display, window, event, binding) {
+    _quickSwitchLayouts(...args) {
+        const binding = args[args.length-1];
         const sources = this._inputSources;
         const nsources = Object.keys(sources).length;
         if (nsources === 0) {


### PR DESCRIPTION
https://gjs.guide/extensions/upgrading/gnome-shell-48.html#inputsourcemanager
Sorry for prev pull-request, forgot to check compatibility with older versions